### PR TITLE
[BugFix] Changed the record generating logic

### DIFF
--- a/AmigoPJT/Command.h
+++ b/AmigoPJT/Command.h
@@ -21,7 +21,6 @@ int Mod(const vector<unsigned int>& founds, string column, string value);
 
 string GenerateCommandRecord(const std::string& command, const bool& detail_print, const vector<unsigned int>& targets);
 string GenerateDetailRecord(const std::string& command, const vector<unsigned int>& result);
-string GenerateSimpleRecord(const std::string& command, const size_t count);
 
 void CommandRun(vector<Command> commands);
 

--- a/AmigoPJT/command.cpp
+++ b/AmigoPJT/command.cpp
@@ -78,38 +78,32 @@ int Mod(const vector<unsigned int>& founds, string column, string value)
     return result.size();
 }
 
-string GenerateCommandRecord(const std::string& command, const bool& detail_print, const vector<unsigned int>& targets)
+string GenerateCommandRecord(const std::string& command, const bool& is_print_list, const vector<unsigned int>& targets)
 {
-    if (detail_print)
+    if (targets.size() < 1)
     {
-        return GenerateDetailRecord(command, targets);
+        return command + ",NONE";
     }
 
-    return GenerateSimpleRecord(command, targets.size());
+    if (!is_print_list)
+    {
+        return command + "," + to_string(targets.size());
+    }
+
+    return GenerateDetailRecord(command, targets);
 }
 
 string GenerateDetailRecord(const std::string& command, const vector<unsigned int>& targets)
 {
     string result = "";
 
-    if (targets.size() > 0)
+    for (size_t i = 0; i < targets.size(); i++)
     {
-        for (const auto& num : targets)
-        {
-            result += GenerateRecord(command, map_employees[num]) + "\n";
-        }
-    }
-    else
-    {
-        result = command + ",NONE";
+        result += GenerateRecord(command, map_employees[targets[i]]);
+        result += (i < targets.size() - 1) ? "\n" : "";
     }
 
     return result;
-}
-
-string GenerateSimpleRecord(const std::string& command, const size_t count)
-{
-    return command + "," + to_string(count);
 }
 
 void CommandRun(vector<Command> commands)

--- a/AmigoPJT/common.h
+++ b/AmigoPJT/common.h
@@ -135,12 +135,12 @@ struct ModificationInfo
 
 static string GenerateRecord(const std::string& cmd, Employee2& employee)
 {
-    string result = cmd + ", ";
-    result += employee.str_employee_num + ", ";
-    result += employee.full_name + ", ";
-    result += employee.cl + ", ";
-    result += employee.full_phone_number + ", ";
-    result += employee.full_birthday + ", ";
+    string result = cmd + ",";
+    result += employee.str_employee_num + ",";
+    result += employee.full_name + ",";
+    result += employee.cl + ",";
+    result += employee.full_phone_number + ",";
+    result += employee.full_birthday + ",";
     result += employee.certi;
     return result;
 }

--- a/Test/test.cpp
+++ b/Test/test.cpp
@@ -266,7 +266,7 @@ namespace ModTest
     {
         vector<string> result = Mod(mod_test_db, found_1_data, ModificationInfo{ Column::BIRTHDAY, "20050520" });
 
-        const string expect_result = "MOD, 17112609, FB NTAWR, CL4, 010-5645-6122, 19861203, PRO";
+        const string expect_result = "MOD,17112609,FB NTAWR,CL4,010-5645-6122,19861203,PRO";
 
         EXPECT_EQ(1, result.size());
         EXPECT_STREQ(expect_result.c_str(), result[0].c_str());
@@ -279,7 +279,7 @@ namespace ModTest
 
         vector<string> result = Mod(mod_test_db, found_1_data, ModificationInfo{ Column::BIRTHDAY, "20050520" });
 
-        const string expect_result = "MOD, 17112609, FB NTAWR, CL4, 010-5645-6122, 20050520, PRO";
+        const string expect_result = "MOD,17112609,FB NTAWR,CL4,010-5645-6122,20050520,PRO";
 
         EXPECT_EQ(1, result.size());
         EXPECT_STREQ(expect_result.c_str(), result[0].c_str());
@@ -294,11 +294,11 @@ namespace ModTest
 
         const string expect_result[]
         {
-            "MOD, 17112609, Anonymous, CL4, 010-5645-6122, 19861203, PRO",
-            "MOD, 02117175, Anonymous, CL4, 010-2814-1699, 19950704, ADV",
-            "MOD, 08123556, Anonymous, CL1, 010-7986-5047, 20100614, PRO",
-            "MOD, 85125741, Anonymous, CL1, 010-8900-1478, 19780228, ADV",
-            "MOD, 11109136, Anonymous, CL4, 010-2627-8566, 19640130, PRO"
+            "MOD,17112609,Anonymous,CL4,010-5645-6122,19861203,PRO",
+            "MOD,02117175,Anonymous,CL4,010-2814-1699,19950704,ADV",
+            "MOD,08123556,Anonymous,CL1,010-7986-5047,20100614,PRO",
+            "MOD,85125741,Anonymous,CL1,010-8900-1478,19780228,ADV",
+            "MOD,11109136,Anonymous,CL4,010-2627-8566,19640130,PRO"
         };
 
         EXPECT_EQ(5, result.size());
@@ -318,11 +318,11 @@ namespace ModTest
 
         const string expect_result[]
         {
-            "MOD, 17112609, FB NTAWR, CL3, 010-5645-6122, 19861203, PRO",
-            "MOD, 02117175, SBILHUT LDEXRI, CL3, 010-2814-1699, 19950704, ADV",
-            "MOD, 08123556, WN XV, CL3, 010-7986-5047, 20100614, PRO",
-            "MOD, 85125741, FBAH RTIJ, CL3, 010-8900-1478, 19780228, ADV",
-            "MOD, 11109136, QKAHCEX LTODDO, CL3, 010-2627-8566, 19640130, PRO"
+            "MOD,17112609,FB NTAWR,CL3,010-5645-6122,19861203,PRO",
+            "MOD,02117175,SBILHUT LDEXRI,CL3,010-2814-1699,19950704,ADV",
+            "MOD,08123556,WN XV,CL3,010-7986-5047,20100614,PRO",
+            "MOD,85125741,FBAH RTIJ,CL3,010-8900-1478,19780228,ADV",
+            "MOD,11109136,QKAHCEX LTODDO,CL3,010-2627-8566,19640130,PRO"
         };
 
         EXPECT_EQ(5, result.size());
@@ -342,11 +342,11 @@ namespace ModTest
 
         const string expect_result[]
         {
-            "MOD, 17112609, FB NTAWR, CL4, 010-1234-0000, 19861203, PRO",
-            "MOD, 02117175, SBILHUT LDEXRI, CL4, 010-1234-0000, 19950704, ADV",
-            "MOD, 08123556, WN XV, CL1, 010-1234-0000, 20100614, PRO",
-            "MOD, 85125741, FBAH RTIJ, CL1, 010-1234-0000, 19780228, ADV",
-            "MOD, 11109136, QKAHCEX LTODDO, CL4, 010-1234-0000, 19640130, PRO"
+            "MOD,17112609,FB NTAWR,CL4,010-1234-0000,19861203,PRO",
+            "MOD,02117175,SBILHUT LDEXRI,CL4,010-1234-0000,19950704,ADV",
+            "MOD,08123556,WN XV,CL1,010-1234-0000,20100614,PRO",
+            "MOD,85125741,FBAH RTIJ,CL1,010-1234-0000,19780228,ADV",
+            "MOD,11109136,QKAHCEX LTODDO,CL4,010-1234-0000,19640130,PRO"
         };
 
         EXPECT_EQ(5, result.size());
@@ -366,11 +366,11 @@ namespace ModTest
 
         const string expect_result[]
         {
-            "MOD, 17112609, FB NTAWR, CL4, 010-5645-6122, 20050520, PRO",
-            "MOD, 02117175, SBILHUT LDEXRI, CL4, 010-2814-1699, 20050520, ADV",
-            "MOD, 08123556, WN XV, CL1, 010-7986-5047, 20050520, PRO",
-            "MOD, 85125741, FBAH RTIJ, CL1, 010-8900-1478, 20050520, ADV",
-            "MOD, 11109136, QKAHCEX LTODDO, CL4, 010-2627-8566, 20050520, PRO"
+            "MOD,17112609,FB NTAWR,CL4,010-5645-6122,20050520,PRO",
+            "MOD,02117175,SBILHUT LDEXRI,CL4,010-2814-1699,20050520,ADV",
+            "MOD,08123556,WN XV,CL1,010-7986-5047,20050520,PRO",
+            "MOD,85125741,FBAH RTIJ,CL1,010-8900-1478,20050520,ADV",
+            "MOD,11109136,QKAHCEX LTODDO,CL4,010-2627-8566,20050520,PRO"
         };
 
         EXPECT_EQ(5, result.size());
@@ -390,11 +390,11 @@ namespace ModTest
 
         const string expect_result[]
         {
-            "MOD, 17112609, FB NTAWR, CL4, 010-5645-6122, 19861203, EX",
-            "MOD, 02117175, SBILHUT LDEXRI, CL4, 010-2814-1699, 19950704, EX",
-            "MOD, 08123556, WN XV, CL1, 010-7986-5047, 20100614, EX",
-            "MOD, 85125741, FBAH RTIJ, CL1, 010-8900-1478, 19780228, EX",
-            "MOD, 11109136, QKAHCEX LTODDO, CL4, 010-2627-8566, 19640130, EX"
+            "MOD,17112609,FB NTAWR,CL4,010-5645-6122,19861203,EX",
+            "MOD,02117175,SBILHUT LDEXRI,CL4,010-2814-1699,19950704,EX",
+            "MOD,08123556,WN XV,CL1,010-7986-5047,20100614,EX",
+            "MOD,85125741,FBAH RTIJ,CL1,010-8900-1478,19780228,EX",
+            "MOD,11109136,QKAHCEX LTODDO,CL4,010-2627-8566,19640130,EX"
         };
 
         EXPECT_EQ(5, result.size());


### PR DESCRIPTION
- 검색 결과 0 개 일 때에는 무조건 {cmd},NONE 으로 표시하도록 수정
- Output record에 ',' 쉼표 사이에 공백 제거